### PR TITLE
Fix draft and error alert bugs

### DIFF
--- a/frontend/src/components/BugTemplateSelector.vue
+++ b/frontend/src/components/BugTemplateSelector.vue
@@ -8,27 +8,21 @@
             filterable
             size="small"
             placeholder="Select template"
-            not-found-text="No saved draft"
+            not-found-text="No Template"
           >
             <Option v-for="(template, index) in templates" :value="index" :key="index">{{ template.name }}</Option>
           </Select>
         </FormItem>
       </i-col>
       <i-col span="12">
-        <FormItem>
-          <template slot="label">
-            <Tooltip content="Clear current draft" placement="bottom" :delay="500">
-              <a>
-                <Icon class="clear-icon" type="md-refresh" @click="onClear" />
-              </a>
-            </Tooltip><span>Draft</span>
-          </template>
+        <FormItem label="Draft">
           <Select
             v-model="selectedDraft"
             filterable
+            clearable
             size="small"
             placeholder="Select a saved draft"
-            not-found-text="No Template"
+            not-found-text="No saved draft"
           >
             <Option
               v-for="(template, index) in cacheList"
@@ -125,13 +119,13 @@ export default {
   margin-bottom: 0px;
   padding-bottom: 5px;
 }
-.clear-icon {
-  font-size: medium;
-}
 .draft-option {
   white-space: normal;
+  position: relative;
 }
 .delete-icon {
   position: absolute;
+  bottom: 10px;
+  margin: auto;
 }
 </style>

--- a/frontend/src/components/BugTemplateSelector.vue
+++ b/frontend/src/components/BugTemplateSelector.vue
@@ -71,10 +71,6 @@ export default {
     onDelete () {
       this.$store.dispatch('deleteCache', this.selectedCache)
       this.isShownDeleteModal = false
-    },
-    onClear () {
-      this.$store.commit('setSelectedCache', '')
-      this.$store.dispatch('loadTemplate')
     }
   },
   computed: {

--- a/frontend/src/components/BugTemplateSelector.vue
+++ b/frontend/src/components/BugTemplateSelector.vue
@@ -15,11 +15,17 @@
         </FormItem>
       </i-col>
       <i-col span="12">
-        <FormItem label="Draft">
+        <FormItem>
+          <template slot="label">
+            <Tooltip content="Clear current draft" placement="bottom" :delay="500">
+              <a>
+                <Icon class="clear-icon" type="md-refresh" @click="onClear" />
+              </a>
+            </Tooltip><span>Draft</span>
+          </template>
           <Select
             v-model="selectedDraft"
             filterable
-            clearable
             size="small"
             placeholder="Select a saved draft"
             not-found-text="No Template"
@@ -28,12 +34,12 @@
               v-for="(template, index) in cacheList"
               :value="template.cacheName"
               :key="index"
+              class="draft-option"
             >{{template.cacheName}}<Icon
-                v-show="template.cacheName===selectedCache"
-                class="icon-form"
-                style="float: right"
-                type="md-trash"
-                @click="isShownDeleteModal = true"
+              v-show="template.cacheName===selectedCache"
+              class="delete-icon"
+              type="md-trash"
+              @click="isShownDeleteModal = true"
               />
             </Option>
           </Select>
@@ -71,6 +77,10 @@ export default {
     onDelete () {
       this.$store.dispatch('deleteCache', this.selectedCache)
       this.isShownDeleteModal = false
+    },
+    onClear () {
+      this.$store.commit('setSelectedCache', '')
+      this.$store.dispatch('loadTemplate')
     }
   },
   computed: {
@@ -114,5 +124,14 @@ export default {
 .split-left-template-selector .ivu-form-item {
   margin-bottom: 0px;
   padding-bottom: 5px;
+}
+.clear-icon {
+  font-size: medium;
+}
+.draft-option {
+  white-space: normal;
+}
+.delete-icon {
+  position: absolute;
 }
 </style>

--- a/frontend/src/components/form/CompoundTextAreaFormItem.vue
+++ b/frontend/src/components/form/CompoundTextAreaFormItem.vue
@@ -30,6 +30,9 @@ export default {
   created () {
     this.$bus.$on('addMessage', this.addDesc)
   },
+  beforeDestroy () {
+    this.$bus.$off('addMessage')
+  },
   methods: {
     addDesc (desc) {
       this.$store.commit('addExtraMsg', { index: this.index, value: desc })

--- a/frontend/src/store/form.js
+++ b/frontend/src/store/form.js
@@ -218,6 +218,7 @@ export default {
           commit('setSubmitLock', false)
         }).catch(error => {
           bus.$emit('msg.error', 'Submit failed error: ' + error.message)
+          commit('setSubmitLock', false)
         })
     },
     loadAttachment ({ state, commit }) {
@@ -364,7 +365,7 @@ export default {
         .then(response => {
           if (response.data.code === 1000) {
             bus.$emit('msg.success', 'Delete success!')
-            commit('setSelectedCache', '')
+            commit('setSelectedCache', null)
             dispatch('loadCacheList')
             dispatch('loadTemplate')
           } else {

--- a/frontend/src/store/form.js
+++ b/frontend/src/store/form.js
@@ -208,15 +208,16 @@ export default {
       api.createIssue(state.templates[state.selectedTemplateIndex], state.templateDetail,
         state.attachmentsList, state.exportAttachmentList)
         .then(response => {
-          for (let failAttach of response.data.export_fail_attachments) {
-            let extensionName = String(failAttach.split('.').slice(-1))
-            bus.$emit('msg.error', `Add ${failAttach} to attachment error: cannot convert data to a ${extensionName} file.`)
+          if (response.data.code === 1000) {
+            for (let failAttach of response.data.export_fail_attachments) {
+              let extensionName = String(failAttach.split('.').slice(-1))
+              bus.$emit('msg.error', `Add ${failAttach} to attachment error: cannot convert data to a ${extensionName} file.`)
+            }
           }
-          bus.$emit('message', response.data.message)
-          commit('setSubmitLock', false)
-        }).catch(response => {
           bus.$emit('message', response.data)
           commit('setSubmitLock', false)
+        }).catch(error => {
+          bus.$emit('msg.error', 'Submit failed error: ' + error.message)
         })
     },
     loadAttachment ({ state, commit }) {
@@ -363,8 +364,9 @@ export default {
         .then(response => {
           if (response.data.code === 1000) {
             bus.$emit('msg.success', 'Delete success!')
-            commit('setSelectedCache', state.selectedCache)
+            commit('setSelectedCache', '')
             dispatch('loadCacheList')
+            dispatch('loadTemplate')
           } else {
             bus.$emit('msg.error', 'Delete failed error: ' + response.data.message)
           }

--- a/lyrebird_bugit/template_loader.py
+++ b/lyrebird_bugit/template_loader.py
@@ -15,7 +15,7 @@ def get_workspace():
     if bugit_workspace and Path(bugit_workspace).exists():
         return Path(bugit_workspace)
 
-    ROOT = application._cm.root
+    ROOT = application._cm.ROOT
     metadata_dir = ROOT/'downloads'/'lyrebird_bugit'
     metadata_dir.mkdir(parents=True, exist_ok=True)
     logger.warning(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='lyrebird-bugit',
-    version='1.12.2',
+    version='1.12.3',
     packages=['lyrebird_bugit'],
     url='https://github.com/Meituan-Dianping/lyrebird-bugit',
     author='HBQA',


### PR DESCRIPTION
1. Fix the bug of the error alert when submission failed.
2. Upgrade the position of the delete draft button.
![image](https://github.com/Meituan-Dianping/lyrebird-bugit/assets/112544421/587bd648-f862-4c24-96ce-237d356e5d4e)
4. Fix the problem that the name of the deleted draft is still displayed in the selection box.
![image](https://github.com/Meituan-Dianping/lyrebird-bugit/assets/112544421/d8a4529b-43f9-4ce2-b700-989b51057dd5)
6. Upgrade the way of clearing and deleting a draft.
![image](https://github.com/Meituan-Dianping/lyrebird-bugit/assets/112544421/f974dd3f-f4ac-4b25-9261-7f1e299d81b1)
7. Fix plug-in startup error: 'ConfigManager' object has no attribute 'root'.
8. Fix duplicate listeners responding repeatedly when adding description.