### PR TITLE
v1.14.1 - Save current draft when using cmd+s

### DIFF
--- a/frontend/src/components/BugTemplateSelector.vue
+++ b/frontend/src/components/BugTemplateSelector.vue
@@ -98,6 +98,7 @@ export default {
       set (val) {
         if (val !== undefined) {
           this.$store.commit('setSelectedCache', val)
+          this.$store.commit('setCreateName', val)
           this.$store.dispatch('loadTemplate')
         }
       }

--- a/frontend/src/components/Bugit.vue
+++ b/frontend/src/components/Bugit.vue
@@ -44,6 +44,14 @@ export default {
     document.addEventListener('keydown', this.onKeyDown)
     document.addEventListener('keyup', this.onKeyUp)
   },
+  beforeDestroy () {
+    this.$bus.$off('message', this.displayMessage)
+    this.$bus.$off('msg.success', this.successMessage)
+    this.$bus.$off('msg.info', this.infoMessage)
+    this.$bus.$off('msg.error', this.errorMessage)
+    this.$bus.$off('msg.loading', this.loadingMessage)
+    this.$bus.$off('msg.destroy', this.destroyMessage)
+  },
   methods: {
     onKeyDown (event) {
       if (event.key === 'Meta') {
@@ -51,7 +59,11 @@ export default {
       } else if (event.key === 's') {
         if (this.metaKey) {
           window.event.preventDefault()
-          this.$store.dispatch('saveCache')
+          if (this.$store.state.form.selectedCache === '') {
+            this.$store.commit('setShownDraftNameModal', true)
+          } else {
+            this.$store.dispatch('saveCache')
+          }
         }
       } else if (event.key === 'Enter' && this.$store.state.form.shownDraftNameModal) {
         this.$store.dispatch('saveCache')

--- a/lyrebird_bugit/apis.py
+++ b/lyrebird_bugit/apis.py
@@ -71,7 +71,7 @@ def template():
             template_detail = template.form()
         
         # 'template_loaded' fields will be ensured to have a uniform value by the script.
-        if template_detail[0]['template_loaded']:
+        if template_detail[0].get('template_loaded'):
             message = None
         else:
             message = 'Template loads failed! Please try again later.'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='lyrebird-bugit',
-    version='1.14.0',
+    version='1.14.1',
     packages=['lyrebird_bugit'],
     url='https://github.com/Meituan-Dianping/lyrebird-bugit',
     author='HBQA',


### PR DESCRIPTION
1. Save current draft when using cmd+s
2. Unsubscribe bus from message listening
3. template_detail[0]['template_loaded'] ——> template_detail[0].get('template_loaded')